### PR TITLE
Adjust Helm chart specification to use new best practice format

### DIFF
--- a/class/cloud-portal.yml
+++ b/class/cloud-portal.yml
@@ -2,10 +2,10 @@ parameters:
   kapitan:
     dependencies:
       - type: helm
-        chart_name: ${cloud_portal:chart:name}
-        version: ${cloud_portal:chart:version}
-        source: ${cloud_portal:chart:source}
-        output_path: dependencies/cloud-portal/helmcharts/cloud-portal/${cloud_portal:chart:name}/${cloud_portal:chart:version}/
+        chart_name: cloud-portal
+        version: ${cloud_portal:charts:cloud-portal:version}
+        source: ${cloud_portal:charts:cloud-portal:source}
+        output_path: dependencies/cloud-portal/helmcharts/cloud-portal/${cloud_portal:charts:cloud-portal:version}/
 
     compile:
       - input_paths:
@@ -21,7 +21,7 @@ parameters:
         input_type: helm
         output_type: yaml
         input_paths:
-          - cloud-portal/helmcharts/cloud-portal/${cloud_portal:chart:name}/${cloud_portal:chart:version}/
+          - cloud-portal/helmcharts/cloud-portal/${cloud_portal:charts:cloud-portal:version}/
         helm_params:
           name: ${cloud_portal:release_name}
           namespace: ${cloud_portal:namespace}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,9 +4,9 @@ parameters:
     namespace: appuio-cloud-portal
 
     release_name: cloud-portal
-    chart:
-      source: https://charts.appuio.ch
-      name: cloud-portal
-      version: "0.3.0"
+    charts:
+      cloud-portal:
+        source: https://charts.appuio.ch
+        version: "0.3.0"
 
     helm_values: {}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -20,31 +20,22 @@ default:: `cloud-portal`
 The name under which the helm chart is deployed.
 
 
-== `chart.source`
+== `charts.cloud-portal.source`
 
 [horizontal]
 type:: string
 default:: `https://charts.appuio.ch`
 
-The Helm repository for the downloaded chart.
+The Helm repository for the `cloud-portal` Helm chart.
 
 
-== `chart.name`
-
-[horizontal]
-type:: string
-default:: `cloud-portal`
-
-The name of the downloaded Helm chart.
-
-
-== `chart.version`
+== `charts.cloud-portal.version`
 
 [horizontal]
 type:: string
-example:: `0.2.1`
+example:: https://github.com/appuio/component-cloud-portal/blob/master/class/defaults.yml[See `class/defaults.yml`]
 
-The version of the downloaded Helm chart.
+The version to use for the `cloud-portal` Helm chart.
 
 
 == `helm_values`


### PR DESCRIPTION
Adjust the Helm chart specification so that Renovate can actually extract the dependency.

The new format for the Helm chart specification used by the PR doesn't match the best practices currently documented on https://syn.tools/syn/explanations/commodore-components/helm-charts.html but matches the proposed changes for the best practices in https://github.com/projectsyn/documentation/pull/150.

Note: this is a breaking change since we replace an existing parameter.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
