### PR TITLE
Expose cloud-portal container image in component parameters

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,9 +4,15 @@ parameters:
     namespace: appuio-cloud-portal
 
     release_name: cloud-portal
+    images:
+      cloud-portal:
+        registry: ghcr.io
+        repository: appuio/cloud-portal
+        tag: v0.9.0
     charts:
       cloud-portal:
         source: https://charts.appuio.ch
         version: "0.4.1"
 
-    helm_values: {}
+    helm_values:
+      image: ${cloud_portal:images:cloud-portal}

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -19,6 +19,15 @@ default:: `cloud-portal`
 
 The name under which the helm chart is deployed.
 
+== `images.cloud-portal`
+
+[horizontal]
+type:: dict
+default:: See https://github.com/appuio/component-cloud-portal/blob/master/class/defaults.yml[`class/defaults.yml`]
+
+The container image to use for the cloud portal deployment.
+The contents of this parameter are passed to the Helm chart in value `image`.
+
 
 == `charts.cloud-portal.source`
 

--- a/tests/golden/defaults/cloud-portal/cloud-portal/01_cloud_portal_helmchart/cloud-portal/templates/deployment.yaml
+++ b/tests/golden/defaults/cloud-portal/cloud-portal/01_cloud_portal_helmchart/cloud-portal/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: cloud-portal
     spec:
       containers:
-        - image: ghcr.io/appuio/cloud-portal:v0.2.1
+        - image: ghcr.io/appuio/cloud-portal:v0.9.0
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:


### PR DESCRIPTION
This will allow commodore-renovate to generate PRs for new cloud-portal releases.

Also update default image version to v0.9.0.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
