### PR TITLE
Implement automatic merges and releases for dependency updates

### DIFF
--- a/.github/workflows/autotag.yaml
+++ b/.github/workflows/autotag.yaml
@@ -91,6 +91,7 @@ jobs:
           body-includes: '🛠️ _Auto release '
       - name: add or update comment on PR
         uses: peter-evans/create-or-update-comment@v2
+        if: github.event.action != 'closed'
         with:
           comment-id: ${{ steps.comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
@@ -109,3 +110,14 @@ jobs:
           newVer: ${{ steps.next-version.outputs.next-version }}
         run: |
           git push origin "${newVer}"
+      - name: Update comment on merged PR
+        uses: peter-evans/create-or-update-comment@v2
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
+        with:
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 This PR has been released as [`${{ steps.next-version.outputs.next-version }}`](https://github.com/${{ github.repository }}/releases/tag/${{ steps.next-version.outputs.next-version }})
+
+            🛠️ _Auto release enabled_ with label `bump:${{ needs.parse-labels.outputs.bump }}`
+          edit-mode: replace

--- a/.github/workflows/autotag.yaml
+++ b/.github/workflows/autotag.yaml
@@ -1,18 +1,62 @@
 name: create tag
 on:
   pull_request:
-    # Run when PR head branch is updated (synchronize), when the PR is
-    # labeled, and after the PR is closed. We additionally check for
-    # `merged==true` in the event payload on `closed` before actually pushing
-    # the tag.
+    # Run when PR head branch is updated (synchronize), when the set of PR
+    # labels is changed (labeled, unlabeled), and after the PR is closed. We
+    # additionally check for `merged==true` in the event payload on `closed`
+    # before actually pushing the tag.
     types:
       - synchronize
       - labeled
+      - unlabeled
       - closed
 
 jobs:
-  tag:
+  parse-labels:
     if: contains(join(github.event.pull_request.labels.*.name, ';'), 'bump:')
+    runs-on: ubuntu-latest
+    outputs:
+      label-count: ${{ steps.bump.outputs.label-count }}
+      bump: ${{ steps.bump.outputs.bump }}
+    steps:
+      - name: extract version bump from labels
+        id: bump
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ';') }}
+        run: |
+          bump=""
+          label_count=0
+          for lbl in $(echo $LABELS | tr ";" "\n"); do
+            if [[ "$lbl" == "bump:"* ]]; then
+              label_count=$(( $label_count + 1 ))
+              bump=${lbl/bump:};
+            fi
+          done
+          echo "found ${label_count} bump labels"
+          echo "version bump: ${bump}"
+          echo "bump=${bump}" >> $GITHUB_OUTPUT
+          echo "label-count=${label_count}" >> $GITHUB_OUTPUT
+      - name: try to find existing comment
+        uses: peter-evans/find-comment@v2
+        id: comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '🛠️ _Auto release'
+      - name: add or update PR comment for too many labels
+        if: steps.bump.outputs.label-count > 1
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Found ${{ steps.bump.outputs.label-count }} `bump:` labels, please make sure you only add one `bump:` label.
+
+            🛠️ _Auto release disabled_
+          edit-mode: replace
+  tag:
+    needs: parse-labels
+    if: needs.parse-labels.outputs.label-count == 1
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,20 +71,10 @@ jobs:
         run: |
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: extract version bump from labels
-        id: bump
-        env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ';') }}
-        run: |
-          bump=""
-          for lbl in $(echo $LABELS | tr ";" "\n"); do echo "processing $lbl"; if [[ "$lbl" == "bump:"* ]]; then bump=${lbl/bump:}; fi; done
-          echo "version bump: ${bump}"
-          echo "bump=${bump}" >> $GITHUB_OUTPUT
       - name: compute next version
-        if: steps.bump.outputs.bump != ''
         id: next-version
         env:
-          bump: ${{ steps.bump.outputs.bump }}
+          bump: ${{ needs.parse-labels.outputs.bump }}
         run: |
           echo "bumping to next ${bump} version"
           curVer=$(git tag --sort=-v:refname | head -n1)
@@ -54,7 +88,7 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
-          body-includes: _Auto-release enabled_ with label
+          body-includes: '🛠️ _Auto release '
       - name: add or update comment on PR
         uses: peter-evans/create-or-update-comment@v2
         with:
@@ -63,15 +97,14 @@ jobs:
           body: |
             🚀 Merging this PR will release `${{ steps.next-version.outputs.next-version }}`
 
-            _Auto-release enabled_ with label `bump:${{ steps.bump.outputs.bump }}`
+            🛠️ _Auto release enabled_ with label `bump:${{ needs.parse-labels.outputs.bump }}`
           edit-mode: replace
       - name: create tag
         env:
           newVer: ${{ steps.next-version.outputs.next-version }}
-        if: steps.bump.outputs.bump != ''
         run: git tag -a -m "${newVer}" "${newVer}"
       - name: push tag (for merged PRs)
-        if: steps.bump.outputs.bump != '' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        if: github.event.action == 'closed' && github.event.pull_request.merged == true
         env:
           newVer: ${{ steps.next-version.outputs.next-version }}
         run: |

--- a/.github/workflows/autotag.yaml
+++ b/.github/workflows/autotag.yaml
@@ -48,6 +48,23 @@ jobs:
           newVer="v$(./semver bump ${bump} $curVer)"
           echo "new version: ${newVer}"
           echo "next-version=${newVer}" >> $GITHUB_OUTPUT
+      - name: try to find existing comment
+        uses: peter-evans/find-comment@v2
+        id: comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: _Auto-release enabled_ with label
+      - name: add or update comment on PR
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{ steps.comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            🚀 Merging this PR will release `${{ steps.next-version.outputs.next-version }}`
+
+            _Auto-release enabled_ with label `bump:${{ steps.bump.outputs.bump }}`
+          edit-mode: replace
       - name: create tag
         env:
           newVer: ${{ steps.next-version.outputs.next-version }}

--- a/.github/workflows/autotag.yaml
+++ b/.github/workflows/autotag.yaml
@@ -1,0 +1,61 @@
+name: create tag
+on:
+  pull_request:
+    # Run when PR head branch is updated (synchronize), when the PR is
+    # labeled, and after the PR is closed. We additionally check for
+    # `merged==true` in the event payload on `closed` before actually pushing
+    # the tag.
+    types:
+      - synchronize
+      - labeled
+      - closed
+
+jobs:
+  tag:
+    if: contains(join(github.event.pull_request.labels.*.name, ';'), 'bump:')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          fetch-depth: "0"
+      - name: install semver
+        run: |
+          curl -LO https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+          chmod +x ./semver
+      - name: configure git user
+        run: |
+          git config --global user.name "$GITHUB_ACTOR"
+          git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: extract version bump from labels
+        id: bump
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ';') }}
+        run: |
+          bump=""
+          for lbl in $(echo $LABELS | tr ";" "\n"); do echo "processing $lbl"; if [[ "$lbl" == "bump:"* ]]; then bump=${lbl/bump:}; fi; done
+          echo "version bump: ${bump}"
+          echo "bump=${bump}" >> $GITHUB_OUTPUT
+      - name: compute next version
+        if: steps.bump.outputs.bump != ''
+        id: next-version
+        env:
+          bump: ${{ steps.bump.outputs.bump }}
+        run: |
+          echo "bumping to next ${bump} version"
+          curVer=$(git tag --sort=-v:refname | head -n1)
+          echo "current version: ${curVer}"
+          newVer="v$(./semver bump ${bump} $curVer)"
+          echo "new version: ${newVer}"
+          echo "next-version=${newVer}" >> $GITHUB_OUTPUT
+      - name: create tag
+        env:
+          newVer: ${{ steps.next-version.outputs.next-version }}
+        if: steps.bump.outputs.bump != ''
+        run: git tag -a -m "${newVer}" "${newVer}"
+      - name: push tag (for merged PRs)
+        if: steps.bump.outputs.bump != '' && github.event.action == 'closed' && github.event.pull_request.merged == true
+        env:
+          newVer: ${{ steps.next-version.outputs.next-version }}
+        run: |
+          git push origin "${newVer}"

--- a/renovate.json
+++ b/renovate.json
@@ -24,11 +24,15 @@
     },
     {
       "matchUpdateTypes": ["minor"],
-      "labels": ["dependency", "bump:minor"]
+      "labels": ["dependency", "bump:minor"],
+      "automerge": true,
+      "platformAutomerge": true
     },
     {
       "matchUpdateTypes": ["patch"],
-      "labels": ["dependency", "bump:patch"]
+      "labels": ["dependency", "bump:patch"],
+      "automerge": true,
+      "platformAutomerge": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,5 +14,21 @@
   "suppressNotifications": [ "artifactErrors" ],
   "labels": [
     "dependency"
+  ],
+  "separateMinorPatch": true,
+  "separateMultipleMajor": true,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependency", "bump:major"]
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "labels": ["dependency", "bump:minor"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "labels": ["dependency", "bump:patch"]
+    }
   ]
 }


### PR DESCRIPTION
We configure Renovate to add additional labels `bump:patch`, `bump:minor` and `bump:major` to dependency PRs, and configure Renovate automerge for minor and patch upgrades.

Additionally, we add a GitHub action which looks for `bump:` labels on PRs and creates new semver tags based on the newest tag (as reported by `git tag -l --sort=-v:refname | head -n1`) and the semver bump extracted from the label. We generate the new version with https://github.com/fsaintjacques/semver-tool. To ensure that the regular release action runs after pushing the new tag from a GitHub action, we use a SSH deploy key with push permissions to push the new tag, as tags pushed by the regular GitHub actions token won't trigger other workflows.

Please note that the auto-tagging action doesn't look at any PRs other than the one it's triggered for. If you want to use `bump:` labels to auto-release changes from your own PRs, please make sure to select the appropriate `bump:` label based on all the unreleased changes.

I've already created the deploy key and configured it on the repo both as a deploy key and as a actions secret. The key was generated with

```
ssh-keygen -t ed25519 -f id_ed25519_appuio_component-cloud-portal -C "github-actions@appuio/component-cloud-portal"
```

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
